### PR TITLE
[Feat]: 비회원 일 경우 Header markup 추가 및 링크 연동

### DIFF
--- a/src/assets/css/global.css
+++ b/src/assets/css/global.css
@@ -17,6 +17,7 @@ html {
 
 body {
   margin: 0 auto;
+  padding: 0 104px 0 104px;
   max-width: 1440px;
   font-size: 1rem;
   font-family: 'Spoqa Han Sans Neo';

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,10 +1,35 @@
 import React from 'react';
 
+import styled from 'styled-components';
+
+import { color } from '#styles/index';
+import Button from '#components/Atoms/Button';
+import { IconPaths, IconWrapper } from '#components/Atoms';
+
 export default function Header() {
   return (
-    <header>
-      <h1>돌아보다,</h1>
-      <button type="button">회원가입 / 로그인</button>
-    </header>
+    <HeaderWrapper>
+      <Logo>돌아보다,</Logo>
+      <Button buttonColor={{ background: color.gray }} to="/login">
+        회원가입 / 로그인
+        <IconWrapper icon={IconPaths.Glitter} />
+      </Button>
+    </HeaderWrapper>
   );
 }
+
+const HeaderWrapper = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 60px 0 60px 0;
+`;
+
+const Logo = styled.h1`
+  font-family: 'RIDIBatang';
+  font-size: 32px;
+  line-height: 32px;
+  font-weight: 400;
+  letter-spacing: -0.06em;
+  color: ${color.gray || 'none'};
+`;


### PR DESCRIPTION
<img width="1904" alt="스크린샷 2021-05-16 오후 5 00 01" src="https://user-images.githubusercontent.com/45390172/118390077-28a9c200-b668-11eb-9560-992d7b9716e4.png">

- 비회원일 경우 디자인에 나온 markup을 추가하였습니다.
- 회원가입 / 로그인 버튼에 link를 추가하였습니다.
- 추후에 login 기능이 추가되어 access token 값을 redux에 저장할 수 있게 되면 다른 디자인이 적용되어야 합니다.