### PR TITLE
Article Detail page 서버 연동

### DIFF
--- a/src/api/articleViewApi.ts
+++ b/src/api/articleViewApi.ts
@@ -1,0 +1,24 @@
+import axios, { AxiosResponse } from 'axios';
+
+export interface ArticleDetailData {
+  category: string;
+  contents: string;
+  created_at: string;
+  nickname: string;
+  postIdx: number;
+  profile: string;
+  tag: Array<string>;
+  title: string;
+  view: number;
+}
+
+export const getArticleDetail = async (index: string): Promise<AxiosResponse | null> => {
+  try {
+    const res = await axios.get(`http://15.165.67.119:9000/api/v1/posts/${index}`);
+    return res.data;
+  } catch (error) {
+    /* eslint-disable no-console */
+    console.log(error);
+    return null;
+  }
+};

--- a/src/components/ArticleView/ArticleDetail/Category.tsx
+++ b/src/components/ArticleView/ArticleDetail/Category.tsx
@@ -6,20 +6,42 @@ interface Props {
   category: string;
 }
 
+interface CategoryType {
+  color: string;
+  title: string;
+  icon: React.FunctionComponent;
+}
+
 const Category = ({ category }: Props) => {
-  const categories: { [key: string]: Array<string> } = {
-    marketing: ['red', '마케팅'],
-    design: ['blue', '디자인'],
-    plan: ['purple', '기획'],
-    develop: ['yellow', '개발'],
+  const categories: { [key: string]: CategoryType } = {
+    marketing: {
+      color: 'red',
+      title: '마케팅',
+      icon: IconPaths.Writing,
+    },
+    design: {
+      color: 'blue',
+      title: '디자인',
+      icon: IconPaths.Palette,
+    },
+    plan: {
+      color: 'purple',
+      title: '기획',
+      icon: IconPaths.Bulb,
+    },
+    develop: {
+      color: 'yellow',
+      title: '개발',
+      icon: IconPaths.Laptop,
+    },
   };
 
   return (
     <>
       {category && (
-        <Button buttonColor={{ background: color[categories[category][0]] }}>
-          {categories[category][1]}
-          <IconWrapper icon={IconPaths.Bulb} />
+        <Button buttonColor={{ background: color[categories[category].color] }}>
+          {categories[category].title}
+          <IconWrapper icon={categories[category].icon} />
         </Button>
       )}
     </>

--- a/src/components/ArticleView/ArticleDetail/Category.tsx
+++ b/src/components/ArticleView/ArticleDetail/Category.tsx
@@ -7,19 +7,21 @@ interface Props {
 }
 
 const Category = ({ category }: Props) => {
-  const categories: { [key: string]: string } = {
-    마케팅: 'red',
-    디자인: 'blue',
-    기획: 'purple',
-    개발: 'yellow',
+  const categories: { [key: string]: Array<string> } = {
+    marketing: ['red', '마케팅'],
+    design: ['blue', '디자인'],
+    plan: ['purple', '기획'],
+    develop: ['yellow', '개발'],
   };
 
   return (
     <>
-      <Button buttonColor={{ background: color[categories[category]] }}>
-        {category}
-        <IconWrapper icon={IconPaths.Glitter} />
-      </Button>
+      {category && (
+        <Button buttonColor={{ background: color[categories[category][0]] }}>
+          {categories[category][1]}
+          <IconWrapper icon={IconPaths.Bulb} />
+        </Button>
+      )}
     </>
   );
 };

--- a/src/components/ArticleView/ArticleDetail/SubtleInfo/Author.tsx
+++ b/src/components/ArticleView/ArticleDetail/SubtleInfo/Author.tsx
@@ -23,6 +23,7 @@ const StyledName = styled.p`
 
 const StyledImg = styled.div<ImgProps>`
   background-image: url(${(props) => props.imgSrc});
+  background-size: cover;
   width: 32px;
   height: 32px;
 

--- a/src/components/ArticleView/ArticleDetail/SubtleInfo/index.tsx
+++ b/src/components/ArticleView/ArticleDetail/SubtleInfo/index.tsx
@@ -6,11 +6,8 @@ import Views from '#components/ArticleView/ArticleDetail/SubtleInfo/Views';
 
 interface Props {
   view: number;
-  user: {
-    idx: number;
-    nickname: string;
-    picture: string;
-  };
+  nickname: string;
+  profile: string;
   date: string;
 }
 
@@ -20,10 +17,10 @@ const StyledSubtleInfo = styled.div`
   margin-bottom: 56px;
 `;
 
-const SubtleInfo = ({ user, date, view }: Props) => {
+const SubtleInfo = ({ nickname, profile, date, view }: Props) => {
   return (
     <StyledSubtleInfo>
-      <Author imgSrc={user.picture} name={user.nickname} />
+      <Author imgSrc={profile} name={nickname} />
       <CreatedAt date={date} />
       <Views count={view} />
     </StyledSubtleInfo>

--- a/src/components/ArticleView/ArticleDetail/index.tsx
+++ b/src/components/ArticleView/ArticleDetail/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Viewer } from '@toast-ui/react-editor';
+import { ArticleDetailData } from 'api/articleViewApi';
 import styled from 'styled-components';
-import { articleDetailFixture as mockup } from '#fixtures/articleDetail';
 import Category from './Category';
 import Title from './Title';
 
@@ -9,6 +9,10 @@ import SubtleInfo from '#components/ArticleView/ArticleDetail/SubtleInfo';
 // import '@toast-ui/editor/dist/toastui-editor.css';
 // import 'codemirror/lib/codemirror.css';
 // import './Style/style.css';
+
+interface Props {
+  data: ArticleDetailData;
+}
 
 const StyleArticleCard = styled.div`
   background-color: #fefefe;
@@ -36,21 +40,21 @@ const StyledViewer = styled.div`
   }
 `;
 
-const ArticleDetailCard = () => {
+const ArticleDetailCard = ({ data }: Props) => {
+  const { contents, category, title, nickname, profile, view, created_at } = data;
   const viewerRef = useRef<Viewer>(null);
+
   useEffect(() => {
     if (viewerRef.current !== null) {
-      const { content } = mockup;
-      if (content) {
-        viewerRef.current.getInstance().setMarkdown(content);
-      }
+      viewerRef.current.getInstance().setMarkdown(contents);
     }
-  }, []);
+  }, [contents]);
+
   return (
     <StyleArticleCard>
-      <Category category={mockup.category} />
-      <Title text={mockup.title} />
-      <SubtleInfo user={mockup.user} view={mockup.view} date={mockup.date} />
+      <Category category={category} />
+      <Title text={title} />
+      <SubtleInfo nickname={nickname} profile={profile} view={view} date={created_at} />
       <StyledViewer>
         <Viewer ref={viewerRef} />
       </StyledViewer>

--- a/src/containers/ArticleDetailContainer/index.tsx
+++ b/src/containers/ArticleDetailContainer/index.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { getArticleDetail } from 'api/articleViewApi';
+import { ArticleDetail } from '#components/ArticleView';
+
+interface Props {
+  id: string;
+}
+
+const ArticleDetailContainer = ({ id }: Props) => {
+  const [data, setData] = useState({
+    category: '',
+    contents: '',
+    created_at: '',
+    nickname: '',
+    postIdx: 0,
+    profile: '',
+    tag: [],
+    title: '',
+    view: 0,
+  });
+
+  const getData = async () => {
+    const apiData = await getArticleDetail(id);
+    if (apiData) {
+      const innerData = apiData.data;
+      setData({
+        ...innerData,
+      });
+    }
+    // else{
+    //    정상적으로 데이터를 가져오지 못한 경우 -> 추후 ui 구현 (ex. 올바르지 않은 접근입니다.)
+    // }
+  };
+
+  useEffect(() => {
+    getData();
+  }, []);
+
+  return (
+    <>
+      <ArticleDetail data={data} />
+    </>
+  );
+};
+
+export default ArticleDetailContainer;

--- a/src/pages/ArticleDetailPage/index.tsx
+++ b/src/pages/ArticleDetailPage/index.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import { ArticleDetail, ProgressBar } from '#components/ArticleView';
+import { RouteComponentProps } from 'react-router';
+import ArticleDetailContainer from '#containers/ArticleDetailContainer';
+import { ProgressBar } from '#components/ArticleView';
 
-const ArticleDetailPage = () => {
+interface MatchParams {
+  id: string;
+}
+
+const ArticleDetailPage = ({ match }: RouteComponentProps<MatchParams>) => {
   return (
     <>
       <ProgressBar />
-      <ArticleDetail />
+      <ArticleDetailContainer id={match.params.id} />
     </>
   );
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28773553/119878795-8346f600-bf65-11eb-85f1-9939906ccf5c.png)

Article Detail 페이지의 목업데이터를 삭제하고
실제 서버에 저장된 데이터를 받아와서 보여주게 했습니다.

카테고리 버튼을 직접 대충 만들어서 썼는데, 형조님이 만드신 카테고리를 수정해서 사용해 볼 수 있을 것 같습니다. 급한 것 마무리하고 고쳐보겠습니다.

서버 데이터 받아와서 저장하는 로직이 많이 어색한데, 일단은 급하게 기능만 붙여봤습니다.
좋은방법 있다면 제안 부탁드립니다🙏🏻
