### PR TITLE
Article edit page 글 쓰기 기능 구현

### DIFF
--- a/src/api/articleEditorApi.ts
+++ b/src/api/articleEditorApi.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+/* eslint-disable no-console */
+// Article Editor
+
+export interface PostArticleData {
+  category: string;
+  contents: string;
+  image: Array<string>;
+  tag: Array<string>;
+  templateIdx: number;
+  title: string | null;
+}
+
+// 글 작성은 로그인이 필요한 기능이므로, 임시로 토큰을 받아와 헤더에 더했습니다.
+const headerData = {
+  Authorization: `Bearer eyJhbGciOiJIUzUxMiJ9.eyJhdXRoIjoiUk9MRV9NRU1CRVIiLCJuaWNrbmFtZSI6IuyehOyduO2YuCIsInVzZXJfaWR4IjozLCJleHAiOjE2MjIxNzYyNjcsImlhdCI6MTYyMjE3NTk2N30.KXHk9kU5kXzWav4FTBA9VZHnqAuQ3VM6ZtK6EGIOHb0XgNoP0VcFO-7que1PjeoJQeh7OuQSwP5pMmkdVoPbFw`,
+};
+
+export const postArticle = async (data: PostArticleData): Promise<number> => {
+  try {
+    const res = await axios.post('http://15.165.67.119:9000/api/v1/posts', data, {
+      headers: headerData,
+    });
+    return res.data.data;
+  } catch (error) {
+    console.log(error);
+    return -1;
+  }
+};

--- a/src/components/ArticleEditor/ArticleEditor/TempSaveBtn.tsx
+++ b/src/components/ArticleEditor/ArticleEditor/TempSaveBtn.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconPaths, IconWrapper, Button } from '#components/Atoms/index';
+import { Button } from '#components/Atoms/index';
 import { color } from '#styles/index';
 
 interface Props {

--- a/src/components/ArticleEditor/ArticleEditor/TempSaveBtn.tsx
+++ b/src/components/ArticleEditor/ArticleEditor/TempSaveBtn.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { IconPaths, IconWrapper, Button } from '#components/Atoms/index';
+import { color } from '#styles/index';
+
+interface Props {
+  onClick: () => void;
+}
+const TempSaveBtn = ({ onClick }: Props) => {
+  return (
+    <>
+      <Button buttonColor={{ background: color.blue }} onClick={onClick}>
+        작성완료
+      </Button>
+    </>
+  );
+};
+
+export default TempSaveBtn;

--- a/src/components/ArticleEditor/ArticleEditor/index.tsx
+++ b/src/components/ArticleEditor/ArticleEditor/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { Editor } from '@toast-ui/react-editor';
 import TitleInput from '#components/ArticleEditor/ArticleEditor/TitleInput';
@@ -7,7 +7,7 @@ import TempSaveBtn from './TempSaveBtn';
 
 interface Props {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  editorRef: React.MutableRefObject<any>;
+  editorRef: React.MutableRefObject<Editor | null>;
   onClick: () => void;
 }
 

--- a/src/components/ArticleEditor/ArticleEditor/index.tsx
+++ b/src/components/ArticleEditor/ArticleEditor/index.tsx
@@ -3,6 +3,13 @@ import styled from 'styled-components';
 import { Editor } from '@toast-ui/react-editor';
 import TitleInput from '#components/ArticleEditor/ArticleEditor/TitleInput';
 import '@toast-ui/editor/dist/toastui-editor.css';
+import TempSaveBtn from './TempSaveBtn';
+
+interface Props {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  editorRef: React.MutableRefObject<any>;
+  onClick: () => void;
+}
 
 const StyledArticleCard = styled.div`
   background-color: #fefefe;
@@ -37,24 +44,7 @@ const StyledViewer = styled.div`
   }
 `;
 
-const ArticleEditor = () => {
-  const editorRef = useRef<Editor | null>(null);
-  const titleRef = useRef<string | null>('');
-
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    titleRef.current = e.target.value;
-  };
-
-  useEffect(() => {
-    if (editorRef.current !== null) {
-      editorRef.current
-        .getInstance()
-        .setHtml(
-          `<table class="custom"><thead><tr><th><br></th><th><br></th></tr></thead><tbody><tr><td><br><br><br><br><br><br><br></td><td><br><br><br><br><br><br><br></td></tr><tr><td><br><br><br><br><br><br><br></td><td><br><br><br><br><br><br><br></td></tr></tbody></table>`,
-        );
-    }
-  }, []);
-
+const ArticleEditor = ({ onChange, editorRef, onClick }: Props) => {
   return (
     <StyledArticleCard>
       <TitleInput onChange={onChange} />
@@ -68,6 +58,7 @@ const ArticleEditor = () => {
           hideModeSwitch
         />
       </StyledViewer>
+      <TempSaveBtn onClick={onClick} />
     </StyledArticleCard>
   );
 };

--- a/src/components/ArticleModal/index.tsx
+++ b/src/components/ArticleModal/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 interface Props {
   onChange: (e: React.ChangeEvent<HTMLSelectElement | HTMLInputElement>) => void;
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick: () => void;
   isWarning: boolean;
   toggle: () => void;
 }

--- a/src/components/ArticleView/ArticleDetail/Category.tsx
+++ b/src/components/ArticleView/ArticleDetail/Category.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import styled from 'styled-components';
+
 import { IconPaths, IconWrapper, Button } from '#components/Atoms/index';
 import { color } from '#styles/index';
 
@@ -11,6 +13,9 @@ interface CategoryType {
   title: string;
   icon: React.FunctionComponent;
 }
+const StyledCategory = styled.div`
+  margin-right: 4px;
+`;
 
 const Category = ({ category }: Props) => {
   const categories: { [key: string]: CategoryType } = {
@@ -37,14 +42,14 @@ const Category = ({ category }: Props) => {
   };
 
   return (
-    <>
+    <StyledCategory>
       {category && (
         <Button buttonColor={{ background: color[categories[category].color] }}>
           {categories[category].title}
           <IconWrapper icon={categories[category].icon} />
         </Button>
       )}
-    </>
+    </StyledCategory>
   );
 };
 

--- a/src/components/ArticleView/ArticleDetail/TagList.tsx
+++ b/src/components/ArticleView/ArticleDetail/TagList.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Button } from '#components/Atoms';
+import { color } from '#styles/index';
+
+interface Props {
+  tag: Array<string>;
+}
+
+const StyledTagList = styled.div`
+  display: flex;
+`;
+
+const StyledTag = styled.span`
+  margin: 0 4px;
+`;
+
+const TagList = ({ tag }: Props) => {
+  let count = 0;
+
+  const indexedTagList = tag.map((item) => {
+    count += 1;
+    return { id: count, text: item };
+  });
+
+  return (
+    <StyledTagList>
+      {indexedTagList.map((item) => {
+        return (
+          <StyledTag key={item.id}>
+            <Button buttonColor={{ background: color.gray }}>{item.text}</Button>
+          </StyledTag>
+        );
+      })}
+    </StyledTagList>
+  );
+};
+
+export default TagList;

--- a/src/components/ArticleView/ArticleDetail/index.tsx
+++ b/src/components/ArticleView/ArticleDetail/index.tsx
@@ -6,6 +6,7 @@ import Category from './Category';
 import Title from './Title';
 
 import SubtleInfo from '#components/ArticleView/ArticleDetail/SubtleInfo';
+import TagList from './TagList';
 // import '@toast-ui/editor/dist/toastui-editor.css';
 // import 'codemirror/lib/codemirror.css';
 // import './Style/style.css';
@@ -40,8 +41,12 @@ const StyledViewer = styled.div`
   }
 `;
 
+const StyledTag = styled.div`
+  display: flex;
+`;
+
 const ArticleDetailCard = ({ data }: Props) => {
-  const { contents, category, title, nickname, profile, view, created_at } = data;
+  const { contents, category, title, nickname, profile, view, created_at, tag } = data;
   const viewerRef = useRef<Viewer>(null);
 
   useEffect(() => {
@@ -52,7 +57,10 @@ const ArticleDetailCard = ({ data }: Props) => {
 
   return (
     <StyleArticleCard>
-      <Category category={category} />
+      <StyledTag>
+        <Category category={category} />
+        <TagList tag={tag} />
+      </StyledTag>
       <Title text={title} />
       <SubtleInfo nickname={nickname} profile={profile} view={view} date={created_at} />
       <StyledViewer>

--- a/src/containers/ArticleEditorContainer/index.tsx
+++ b/src/containers/ArticleEditorContainer/index.tsx
@@ -1,12 +1,22 @@
 import React, { useEffect, useRef } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Editor } from '@toast-ui/react-editor';
+import { postArticle, PostArticleData } from 'api/articleEditorApi';
 import { useAppSelector } from '#hooks/useAppSelector';
 import ArticleEditor from '#components/ArticleEditor/ArticleEditor';
 
 const ArticleEditorContainer = () => {
+  const history = useHistory();
   const editorRef = useRef<Editor | null>(null);
   const titleRef = useRef<string | null>('');
   const { tag, category } = useAppSelector((state) => state.articleEditorReducer);
+
+  const callApi = async (data: PostArticleData) => {
+    const index = await postArticle(data);
+    if (index !== -1) {
+      history.push(`/articleDetail/${index}`);
+    }
+  };
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     titleRef.current = e.target.value;
@@ -23,7 +33,7 @@ const ArticleEditorContainer = () => {
         templateIdx: 0,
         title: titleRef.current,
       };
-      console.log(data);
+      callApi(data);
     }
   };
 

--- a/src/containers/ArticleEditorContainer/index.tsx
+++ b/src/containers/ArticleEditorContainer/index.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef } from 'react';
+import { Editor } from '@toast-ui/react-editor';
+import { useAppSelector } from '#hooks/useAppSelector';
+import ArticleEditor from '#components/ArticleEditor/ArticleEditor';
+
+const ArticleEditorContainer = () => {
+  const editorRef = useRef<Editor | null>(null);
+  const titleRef = useRef<string | null>('');
+  const { tag, category } = useAppSelector((state) => state.articleEditorReducer);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    titleRef.current = e.target.value;
+  };
+
+  const onClick = () => {
+    /* eslint-disable no-console */
+    if (editorRef.current !== null) {
+      const data = {
+        category,
+        contents: editorRef.current.getInstance().getSquire().getBody().innerHTML,
+        image: [],
+        tag,
+        templateIdx: 0,
+        title: titleRef.current,
+      };
+      console.log(data);
+    }
+  };
+
+  useEffect(() => {
+    if (editorRef.current !== null) {
+      editorRef.current
+        .getInstance()
+        .setHtml(
+          `<table class="custom"><thead><tr><th><br></th><th><br></th></tr></thead><tbody><tr><td><br><br><br><br><br><br><br></td><td><br><br><br><br><br><br><br></td></tr><tr><td><br><br><br><br><br><br><br></td><td><br><br><br><br><br><br><br></td></tr></tbody></table>`,
+        );
+    }
+  }, []);
+
+  return (
+    <>
+      <ArticleEditor onChange={onChange} editorRef={editorRef} onClick={onClick} />
+    </>
+  );
+};
+
+export default ArticleEditorContainer;

--- a/src/containers/ArticleModalContainer/index.tsx
+++ b/src/containers/ArticleModalContainer/index.tsx
@@ -1,9 +1,14 @@
 import React, { useState } from 'react';
+import { EditorState, editorActions } from 'slices/articleEditorSlice';
+import { useHistory } from 'react-router-dom';
 import ArticleModal from '#components/ArticleModal';
 import { IconPaths, IconWrapper, Button } from '#components/Atoms';
 import { color } from '#styles/index';
+import { useAppDispatch } from '#hooks/useAppDispatch';
 
 const ArticleModalContainer = () => {
+  const dispatch = useAppDispatch();
+  const history = useHistory();
   const [modal, setModal] = useState(false);
   const modalToggle = () => setModal(!modal);
 
@@ -33,8 +38,14 @@ const ArticleModalContainer = () => {
       .filter((tmp) => tmp !== '');
 
     // 리덕스에 저장
+    const reduxData: EditorState = {
+      category: data.category,
+      tag: tagList,
+    };
+    dispatch(editorActions.setEditorData(reduxData));
 
     // 페이지 이동
+    history.push('/articleEditor');
   };
 
   return (

--- a/src/containers/ArticleModalContainer/index.tsx
+++ b/src/containers/ArticleModalContainer/index.tsx
@@ -23,7 +23,7 @@ const ArticleModalContainer = () => {
     setData({ ...data, [e.target.name]: e.target.value });
   };
 
-  const onClickWriteBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const onClickWriteBtn = () => {
     // 카테고리 유효성 검사
     if (data.category === '') {
       setWarning(true);

--- a/src/pages/ArticleEditorPage/index.tsx
+++ b/src/pages/ArticleEditorPage/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import ArticleEditor from '#components/ArticleEditor/ArticleEditor';
+import ArticleEditorContainer from '#containers/ArticleEditorContainer';
 
 const ArticleEditorPage = () => {
   return (
     <>
-      <ArticleEditor />
+      <ArticleEditorContainer />
     </>
   );
 };

--- a/src/slices/articleEditorSlice.ts
+++ b/src/slices/articleEditorSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface EditorState {
+  category: string;
+  tag: Array<string>;
+}
+
+const initialState: EditorState = {
+  category: '',
+  tag: [],
+};
+/* eslint-disable no-param-reassign */
+const { actions: editorActions, reducer: articleEditorReducer } = createSlice({
+  name: 'articleEditor',
+  initialState,
+  reducers: {
+    setEditorData: (state, action: PayloadAction<EditorState>) => {
+      state.category = action.payload.category;
+      state.tag = action.payload.tag;
+    },
+  },
+});
+
+export { editorActions, EditorState };
+export default articleEditorReducer;

--- a/src/slices/index.ts
+++ b/src/slices/index.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import cardsReducer from './cardsSlice';
+import articleEditorReducer from './articleEditorSlice';
 
 export const store = configureStore({
   reducer: {
     cardsReducer,
+    articleEditorReducer,
   },
 });
 


### PR DESCRIPTION
메인페이지 하단에서 바로 회고하기 버튼으로 모달을 띄우고,
모달에서 카테고리와 태그를 작성하여 버튼을 클릭하면
editor 페이지로 이동하고, 리덕스에 모달에서 입력한 정보가 들어갑니다.

이후 글을 작성하고 작성완료 버튼을 누르면, 서버에 리덕스와 state 값들을 취합해서 리퀘스트를 보내고
200 응답과 함께, db에 저장된 해당 글의 인덱스를 response로 받습니다.
받은 index로 바로 detailpage로 이동하여 해당 글의 상세보기 페이지로 이동됩니다.