### PR TITLE
메인 페이지 내의 최신순/조회순 글 목록을 요청하는 dropdown 박스를 제거한다

### DIFF
--- a/src/apis/fetchCardList.ts
+++ b/src/apis/fetchCardList.ts
@@ -15,14 +15,8 @@ interface Card {
 }
 
 // const baseUrl = 'http://ec2-15-165-67-119.ap-northeast-2.compute.amazonaws.com/api/v1';
-
-const urls: { [key: string]: string } = {
-  최신순: `/posts/lists/new?page=0&pageSize=20`,
-  조회순: `/posts/lists?page=0&pageSize=20`,
-};
-
-export const fetchCardList = async ({ sortBy }: { sortBy: string }): Promise<Card[]> => {
-  const url = urls[sortBy];
+export const fetchCardList = async (): Promise<Card[]> => {
+  const url = '/posts/lists?page=0&pageSize=20';
 
   try {
     const { data } = await instance.get(url);

--- a/src/components/Atoms/Categories/index.stories.tsx
+++ b/src/components/Atoms/Categories/index.stories.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import { action } from '@storybook/addon-actions';
-import Categories, { Props } from './index';
+import { Meta } from '@storybook/react/types-6-0';
+import Categories from './index';
 
 export default {
   title: 'Atoms/Categories',
   component: Categories,
 } as Meta;
 
-const CategoriesTemplate: Story<Props> = () => {
-  return <Categories onClickDropdownItem={action('onClick')} />;
+const CategoriesTemplate = () => {
+  return <Categories />;
 };
 export const BasicCategories = CategoriesTemplate.bind({});

--- a/src/components/Atoms/Categories/index.tsx
+++ b/src/components/Atoms/Categories/index.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import * as S from './style';
-import { Dropdown, IconPaths, IconWrapper } from '#components/Atoms';
+import { IconPaths, IconWrapper } from '#components/Atoms';
 
-export interface Props {
-  onClickDropdownItem: (sortBy: string) => void;
-}
-
-export default function Categories({ onClickDropdownItem }: Props) {
+export default function Categories() {
   const categories = [
     { text: '전체', value: 'total', icon: IconPaths.Glitter },
     { text: '마케팅', value: 'marketing', icon: IconPaths.Writing },
@@ -17,7 +13,6 @@ export default function Categories({ onClickDropdownItem }: Props) {
 
   return (
     <S.Categories>
-      <Dropdown onClickDropdownItem={onClickDropdownItem} />
       {categories.map(({ text, value, icon }) => (
         <S.Category key={text}>
           <S.Input type="radio" id={value} name="category-radio-group" />

--- a/src/containers/CardsContainer/index.tsx
+++ b/src/containers/CardsContainer/index.tsx
@@ -14,11 +14,10 @@ interface Props {
 export default function CardsContainer({ onClickCard }: Props) {
   const dispatch = useAppDispatch();
   const { cards } = useAppSelector((state) => state.cardsReducer);
-  const { sortBy } = useAppSelector((state) => state.conditionReducer);
 
   useEffect(() => {
-    dispatch(fetchCards({ sortBy }));
-  }, [sortBy]);
+    dispatch(fetchCards());
+  }, []);
 
   return <Cards cards={cards} onClickCard={onClickCard} />;
 }

--- a/src/containers/ConditionContainer/index.tsx
+++ b/src/containers/ConditionContainer/index.tsx
@@ -2,20 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 import { Categories, SearchForm } from '#components/Atoms';
 
-import { useAppDispatch } from '#hooks/useAppDispatch';
-
-import { setSortBy } from '../../slices/conditionSlice';
-
 export default function ConditionContainer() {
-  const dispatch = useAppDispatch();
-
-  const handleClickDropdownItem = (sortBy: string) => {
-    dispatch(setSortBy(sortBy));
-  };
-
   return (
     <Conditions>
-      <Categories onClickDropdownItem={handleClickDropdownItem} />
+      <Categories />
       <SearchForm />
     </Conditions>
   );

--- a/src/slices/cardsSlice.ts
+++ b/src/slices/cardsSlice.ts
@@ -22,9 +22,9 @@ export const { setCards } = actions;
 
 export default cardsReducer;
 
-export function fetchCards({ sortBy }: { sortBy: string }): AppThunk {
+export function fetchCards(): AppThunk {
   return async (dispatch) => {
-    const cards = await fetchCardList({ sortBy });
+    const cards = await fetchCardList();
     dispatch(setCards(cards));
   };
 }

--- a/src/slices/conditionSlice.ts
+++ b/src/slices/conditionSlice.ts
@@ -1,19 +1,9 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-const { actions, reducer: conditionReducer } = createSlice({
+const { reducer: conditionReducer } = createSlice({
   name: 'condition',
-  initialState: {
-    sortBy: '최신순',
-  },
-  reducers: {
-    setSortBy(state, { payload: sortBy }) {
-      return {
-        ...state,
-        sortBy,
-      };
-    },
-  },
+  initialState: {},
+  reducers: {},
 });
 
-export const { setSortBy } = actions;
 export default conditionReducer;


### PR DESCRIPTION
메인 페이지에서는 조회순 글 목록만 조회하기 때문에 `최신순/조회순` dropdown을 main 페이지에서 제거합니다.