### PR TITLE
이미지 업로드방식 Base64 -> 이미지 s3업로드 후, 이미지 리스트 전달

### DIFF
--- a/src/apis/articleEditorApi.ts
+++ b/src/apis/articleEditorApi.ts
@@ -15,6 +15,7 @@ export interface UpdateArticleData {
   contents: string;
   title: string | null;
   tagList: Array<string>;
+  imageList: Array<string>;
 }
 
 export const postArticle = async (data: PostArticleData): Promise<number | null> => {

--- a/src/apis/articleEditorApi.ts
+++ b/src/apis/articleEditorApi.ts
@@ -50,3 +50,15 @@ export const getTemplate = async (templateIdx: number): Promise<string | null> =
     return null;
   }
 };
+
+export const uploadImage = async (image: Blob | File): Promise<string | null> => {
+  try {
+    const formData = new FormData();
+    formData.append('file', image);
+    const res = await tokenInstance.post(`/images`, formData);
+    return res.data.data;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+};

--- a/src/apis/articleViewApi.ts
+++ b/src/apis/articleViewApi.ts
@@ -48,3 +48,23 @@ export const deleteArticle = async (index: string): Promise<AxiosResponse | null
     return null;
   }
 };
+
+export const scrapArticle = async (index: number): Promise<AxiosResponse | null> => {
+  try {
+    const res = await tokenInstance.post(`/likes`, { postIdx: index });
+    return res.data;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+};
+
+export const cancelScrapArticle = async (index: number): Promise<AxiosResponse | null> => {
+  try {
+    const res = await tokenInstance.delete(`/likes/${index}`);
+    return res.data;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+};

--- a/src/apis/common.ts
+++ b/src/apis/common.ts
@@ -23,7 +23,16 @@ const refreshInstance = axios.create({
   },
 });
 
+// 유효한 토큰으로 요청하는 instance
+const imageInstance = axios.create({
+  baseURL: 'http://15.165.67.119/api/v1/',
+  headers: {
+    Authorization: `Bearer ${window.localStorage.getItem('accessToken')}`,
+    'Content-Type': 'multipart/form-data',
+  },
+});
 tokenInstance.interceptors.request.use(checkTokenIntercepter);
+imageInstance.interceptors.request.use(checkTokenIntercepter);
 refreshInstance.interceptors.request.use(putExpiredAccessTokenIntercepter);
 
 export { instance, refreshInstance, tokenInstance };

--- a/src/components/ArticleEditor/ArticleEditor/index.tsx
+++ b/src/components/ArticleEditor/ArticleEditor/index.tsx
@@ -5,6 +5,7 @@ import TitleInput from '#components/ArticleEditor/ArticleEditor/TitleInput';
 import '@toast-ui/editor/dist/toastui-editor.css';
 import TempSaveBtn from './TempSaveBtn';
 import ArticleModalContainer from '#containers/ArticleModalContainer';
+import { uploadImage } from '#apis/articleEditorApi';
 
 interface Props {
   onChangeTitle: (title: string) => void;
@@ -59,6 +60,16 @@ const ArticleEditor = ({ onChangeTitle, editorRef, onClickSaveBtn, initialValue 
           useCommandShortcut
           hideModeSwitch
           ref={editorRef}
+          hooks={{
+            // Base64가 아닌 이미지 처리
+            addImageBlobHook: async (blob, callback) => {
+              const uploadedImageURL = await uploadImage(blob);
+              if (uploadedImageURL) {
+                callback(uploadedImageURL, 'alt text');
+              }
+              return false;
+            },
+          }}
         />
       </StyledViewer>
       <ArticleModalContainer />

--- a/src/components/ArticleView/FloatingBanner/index.tsx
+++ b/src/components/ArticleView/FloatingBanner/index.tsx
@@ -24,8 +24,10 @@ const FloatingBanner = () => {
   const [isScrap, setIsScrap] = useState(false);
   const toggleScrap = () => {
     if (isScrap) {
+      // 스크랩 취소
       setIsScrap(!isScrap);
     } else {
+      // 스크랩 하기
       setIsScrap(!isScrap);
     }
   };

--- a/src/components/ArticleView/FloatingBanner/index.tsx
+++ b/src/components/ArticleView/FloatingBanner/index.tsx
@@ -6,6 +6,8 @@ import Share from './svg/Share';
 import Comment from './svg/Comment';
 import ShareOption from './ShareOption';
 import Shortcut from './Shortcut';
+import { cancelScrapArticle, scrapArticle } from '#apis/articleViewApi';
+import { useAppSelector } from '#hooks/useAppSelector';
 
 const StyledFloatingBanner = styled.div`
   display: flex;
@@ -21,13 +23,23 @@ const StyledFloatingBanner = styled.div`
 
 const FloatingBanner = () => {
   // scrap 여부, 토글에 따른 동작 분기
+
+  const { index } = useAppSelector((state) => state.articleViewReducer);
   const [isScrap, setIsScrap] = useState(false);
-  const toggleScrap = () => {
+  let isRunning = false;
+  const toggleScrap = async () => {
+    if (isRunning) {
+      return;
+    }
     if (isScrap) {
       // 스크랩 취소
+      isRunning = true;
+      await cancelScrapArticle(index);
       setIsScrap(!isScrap);
     } else {
       // 스크랩 하기
+      isRunning = true;
+      await scrapArticle(index);
       setIsScrap(!isScrap);
     }
   };

--- a/src/components/Organisms/Modal/LoginModal.tsx
+++ b/src/components/Organisms/Modal/LoginModal.tsx
@@ -47,14 +47,14 @@ const LoginModal = ({ className = [], isShowed = false, onCloseModal }: Props) =
         <div className="button-wrapper">
           <Button
             buttonColor={{ background: 'google' }}
-            href="http://ec2-15-165-67-119.ap-northeast-2.compute.amazonaws.com/api/v1/auth/google"
+            href="http://ec2-15-165-67-119.ap-northeast-2.compute.amazonaws.com/api/v1/oauth2/google"
           >
             <IconWrapper icon={IconPaths.Google} />
             구글
           </Button>
           <Button
             buttonColor={{ background: 'kakao', textColor: 'kakaoText' }}
-            href="http://ec2-15-165-67-119.ap-northeast-2.compute.amazonaws.com/api/v1/auth/kakao"
+            href="http://ec2-15-165-67-119.ap-northeast-2.compute.amazonaws.com/api/v1/oauth2/kakao"
           >
             <IconWrapper icon={IconPaths.Kakao} />
             카카오

--- a/src/containers/ArticleCreateContainer/index.tsx
+++ b/src/containers/ArticleCreateContainer/index.tsx
@@ -9,6 +9,23 @@ import ArticleEditor from '#components/ArticleEditor/ArticleEditor';
 import ConfirmModalContainer from '#containers/ConfirmModalContainer';
 
 const ArticleCreateContainer = () => {
+  // 추후 util 함수로 빼기
+  const findImageUrlList = (contents: string) => {
+    let m;
+    const rex = /<img[^>]*src=["']?([^>"']+)["']?[^>]*>/g;
+    const urls: Array<string> = [];
+    while (contents) {
+      m = rex.exec(contents);
+      if (!m) {
+        break;
+      }
+      urls.push(m[1]);
+    }
+    /* eslint-disable no-console */
+    // console.log(urls);
+    return urls;
+  };
+
   const history = useHistory();
   const dispatch = useDispatch();
 
@@ -35,7 +52,9 @@ const ArticleCreateContainer = () => {
         templateIdx,
         contents: editorRef.current.getInstance().getSquire().getBody().innerHTML,
         title: titleRef.current,
-        imageList: [],
+        imageList: findImageUrlList(
+          editorRef.current.getInstance().getSquire().getBody().innerHTML,
+        ),
       };
       const index = await postArticle(data);
 

--- a/src/containers/ArticleUpdateContainer/index.tsx
+++ b/src/containers/ArticleUpdateContainer/index.tsx
@@ -38,6 +38,7 @@ const ArticleUpdateContainer = () => {
         contents: editorRef.current.getInstance().getSquire().getBody().innerHTML,
         tagList: updatedTag,
         title: titleRef.current,
+        imageList: [],
       };
 
       const result = await updateArticle(index, data);

--- a/src/containers/ArticleUpdateContainer/index.tsx
+++ b/src/containers/ArticleUpdateContainer/index.tsx
@@ -10,6 +10,22 @@ import ConfirmModalContainer from '#containers/ConfirmModalContainer';
 import { tagData } from '#apis/articleViewApi';
 
 const ArticleUpdateContainer = () => {
+  // 추후 util 함수로 빼기
+  const findImageUrlList = (contents: string) => {
+    let m;
+    const rex = /<img[^>]*src=["']?([^>"']+)["']?[^>]*>/g;
+    const urls: Array<string> = [];
+    while (contents) {
+      m = rex.exec(contents);
+      if (!m) {
+        break;
+      }
+      urls.push(m[1]);
+    }
+    /* eslint-disable no-console */
+    // console.log(urls);
+    return urls;
+  };
   const history = useHistory();
   const dispatch = useDispatch();
   const editorRef = useRef<Editor | null>(null);
@@ -38,14 +54,15 @@ const ArticleUpdateContainer = () => {
         contents: editorRef.current.getInstance().getSquire().getBody().innerHTML,
         tagList: updatedTag,
         title: titleRef.current,
-        imageList: [],
+        imageList: findImageUrlList(
+          editorRef.current.getInstance().getSquire().getBody().innerHTML,
+        ),
       };
 
       const result = await updateArticle(index, data);
 
       if (result) {
         dispatch(editorActions.clearEditorSlice());
-
         history.push(`/articleDetail/${index}`);
       }
     }


### PR DESCRIPTION
이미지 업로드 방식을 변경해서, 서버의 수정사항을 반영했습니다.

추후 이미지 리스트를 추출하는 정규표현식 함수를 util함수로 추출하고, 
임시저장 관련 기획이 나오면, 이미지만 업로드하고 실제 포스팅하지 않아 생기는 가비지 데이터를 날릴 방법을 구상할 예정입니다.